### PR TITLE
Update npm:braces:2.3.1 to 2.3.2-lineaje-01

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "arr-diff": "^4.0.0",
     "array-unique": "^0.3.2",
-    "braces": "^2.3.1",
+    "braces": "2.3.2-lineaje-01",
     "define-property": "^2.0.2",
     "extend-shallow": "^3.0.2",
     "extglob": "^2.0.4",


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:

| CVE ID  | Severity | Description       |
|-------|-----|-----------|
| CVE-2024-4068 | High  | The NPM package `braces`, versions prior to 3.0.3, fails to limit the number of characters </br>it can handle, which could lead to Memory Exhaustion. In `lib/parse.js,` if a malicious </br>user sends "imbalanced braces" as input, the parsing will enter a loop, which will cause </br>the program to start allocating heap memory without freeing it at any moment of the loop. </br>Eventually, the JavaScript heap limit is reached, and the program will crash. |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket: